### PR TITLE
add burst mode to pods

### DIFF
--- a/k8s/peerprep-fe.yml
+++ b/k8s/peerprep-fe.yml
@@ -21,6 +21,13 @@ spec:
         - name: peerprep-fe
           image: asia-southeast1-docker.pkg.dev/cs3219-g11-peerprep/cs3219-g11-repo/peerprep-fe:latest
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 3000
           envFrom:

--- a/k8s/question-service.yml
+++ b/k8s/question-service.yml
@@ -21,6 +21,13 @@ spec:
         - name: question-svc
           image: asia-southeast1-docker.pkg.dev/cs3219-g11-peerprep/cs3219-g11-repo/question-svc:latest
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 4001
           envFrom:

--- a/k8s/redis-server.yml
+++ b/k8s/redis-server.yml
@@ -17,6 +17,13 @@ spec:
         - name: redis-server
           image: redis:latest
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 6379
       dnsPolicy: ClusterFirst

--- a/k8s/user-service.yml
+++ b/k8s/user-service.yml
@@ -21,6 +21,13 @@ spec:
         - name: user-svc
           image: asia-southeast1-docker.pkg.dev/cs3219-g11-peerprep/cs3219-g11-repo/user-svc:latest
           imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "200m"
+              memory: "256Mi"
           ports:
             - containerPort: 3001
           envFrom:


### PR DESCRIPTION
This PR modifies the manifest files for GKE to add burst mode for our pods. This is a temporary fix for #68, where we are experiencing quota exceeds for persistant disk storage. With burst mode, GKE will respect the allocated resources and it might reduce the number of nodes provisioned. 